### PR TITLE
Naming things: Adjust base URI query parameter, default port, and Vite's `base` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can see more screenshots in `/screenshots`
 The easiest way of getting started is to run a docker container:
 
 ```shell
-docker run -p 3000:80 surister/cratedbaltadmin:latest
+docker run -p 9000:80 surister/cratedbaltadmin:latest
 ```
 
 We also upload different versions, more
@@ -71,13 +71,13 @@ When running CrateDB, please make sure to enable *Cross-Origin
 Resource Sharing* in your [CrateDB configuration], like:
 ```
 -Chttp.cors.enabled=true
--Chttp.cors.allow-origin=http://localhost:3000
+-Chttp.cors.allow-origin=http://localhost:9000
 ```
 
 When invoking cratedb-admin-alt, you need to supply the `base_uri` parameter,
 like this:
 ```
-http://localhost:3000/?base_uri=http://localhost:4200
+http://localhost:9000/?base_uri=http://localhost:4200
 ```
 
 An incantation example using Docker would be:
@@ -90,7 +90,7 @@ docker run --rm -d \
       crate -Cnetwork.host=_site_ \
             -Cnode.name=crate01 \
             -Chttp.cors.enabled=true \
-            -Chttp.cors.allow-origin=http://localhost:3000
+            -Chttp.cors.allow-origin=http://localhost:9000
 ```
 
 Bear in mind that if you run the admin panel from another port, it will have to match

--- a/README.md
+++ b/README.md
@@ -65,20 +65,22 @@ If you are running <5.4, the admin ui might not fully work;
 I would only rely on basic console querying, since many features depend on CrateDB >2-3 version;
 again, you shouldn't be running such an old version, upgrade your CrateDB cluster!
 
-## Solving the cors 'issue'
+## Solving the CORS 'issue'
 
-To query CrateDB's HTTP endpoint, you need to start the cluster with Cors headers
-enabled; these are the CrateDB options:
-
-https://cratedb.com/docs/crate/reference/en/latest/config/node.html#cross-origin-resource-sharing-cors
-
+When running CrateDB, please make sure to enable *Cross-Origin
+Resource Sharing* in your [CrateDB configuration], like:
 ```
 -Chttp.cors.enabled=true
 -Chttp.cors.allow-origin=http://localhost:3000
 ```
 
-An example in docker would be:
+When invoking cratedb-admin-alt, you need to supply the `base_uri` parameter,
+like this:
+```
+http://localhost:3000/?base_uri=http://localhost:4200
+```
 
+An incantation example using Docker would be:
 ```shell
 docker run --rm -d \
       --name=crate01 \
@@ -142,3 +144,6 @@ We do not support restoring a snapshot from a partition.
 This project is currently being developed by me, but it's open for contributions, also if you
 have some ideas, feature request or happen to find a bug, please let me know in an issue, so it can
 be addressed.
+
+
+[CrateDB configuration]: https://cratedb.com/docs/crate/reference/en/latest/config/node.html#cross-origin-resource-sharing-cors

--- a/src/store/storedPreferences.js
+++ b/src/store/storedPreferences.js
@@ -27,8 +27,8 @@ export const use_stored_preferences_store = defineStore('stored_preferences', ()
         const state = reactive(defaultState)
         const theme = useTheme()
         const router = useRoute()
-        if (router.query.node_uri){
-          state.general.master_node_url = router.query.node_uri
+        if (router.query.base_uri){
+          state.general.master_node_url = router.query.base_uri
         }
 
         function delete_from_history(query_id) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,6 +45,6 @@ export default defineConfig({
     ],
   },
   server: {
-    port: 3000,
+    port: 9000,
   },
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [
     vue({
       template: { transformAssetUrls }


### PR DESCRIPTION
Hi @surister.

Coming from the aim to include the application into a zoo of more services, all served per Docker Compose, we've just staged a quick patch that hopefully doesn't change much other than improving the situation in this scenario. We hope you like the adjustments.

I've just wrote the changes down on a best effort, but didn't have the chance to test them yet. Do you think they are viable, so you can support us on bringing them in, eventually adjusting the patch where needed, or providing relevant guidance?

- [Naming things: Use `base_uri` query parameter for addressing CrateDB](https://github.com/surister/cratedb-admin-alt/commit/90d0bbfcc19e2adb1ccc7e56b315def87d5920c6)
- [Naming things: Use port 9000, because 3000 is used by Grafana](https://github.com/surister/cratedb-admin-alt/commit/﻿﻿8b8b711f8639e1545f23dd4de5f5af37e8849ecf)
- [Vite: Enable serving application from non-root URL paths](https://github.com/surister/cratedb-admin-alt/commit/eb9b967a6109b17b6746156be593d9f032f996c0)

#### References
- GH-40
- GH-41
